### PR TITLE
Solves issue with discovery using Zeroconf

### DIFF
--- a/owntone/root/defaults/librespot-java.toml
+++ b/owntone/root/defaults/librespot-java.toml
@@ -63,7 +63,7 @@ preferredLocale = "en"
 ### Zeroconf ###
 [zeroconf]
 	# Listen on all interfaces (overrides `zeroconf.interfaces`)
-	listenAll = false
+	listenAll = true
 	# Listen on these interfaces (comma separated list of names)
 	interfaces = "eth0"
 	# Listen on this TCP port (`-1` for random)


### PR DESCRIPTION
Listens on all interfaces by default. 
Spotify Connect will work now "out of the box" and will show up in Spotify apps without providing explicit credentials via USER_PASS strategy.

It is a slightly brute force fix that should simply work. Perfect fix would target the right interface name, most likely the network interface in docker container  is callled differently than 'eth0' so listenting on that particular interface prevents Zeroconf from doing its own thing.