### PR TITLE
Include an Airplay 1 source and Airplay 1 sink in HomePod Connect

### DIFF
--- a/owntone/Dockerfile
+++ b/owntone/Dockerfile
@@ -1,14 +1,127 @@
-FROM ghcr.io/linuxserver/daapd:28.8-ls118
+
+
+FROM ghcr.io/linuxserver/daapd:28.8-ls122 AS owntone
+
 
 # renovate: datasource=github-releases depName=librespot-org/librespot-java
 ENV LIBRESPOT_VERSION=1.6.3
+ARG BASHIO_VERSION="v0.15.0"
 
 RUN echo "**** install java and remove librespot ****" && \
     apk add -U --update --no-cache \
-      openjdk11-jre && \
+      openjdk11-jre && \  
     apk del \
       librespot && \
-    rm -r /etc/s6-overlay/s6-rc.d/user/contents.d/svc-librespot /etc/s6-overlay/s6-rc.d/svc-librespot
+    rm -r /etc/s6-overlay/s6-rc.d/user/contents.d/svc-librespot /etc/s6-overlay/s6-rc.d/svc-librespot && \
+   curl -J -L -o /tmp/bashio.tar.gz \
+        "https://github.com/hassio-addons/bashio/archive/${BASHIO_VERSION}.tar.gz" \
+    && mkdir /tmp/bashio \
+    && tar zxvf \
+        /tmp/bashio.tar.gz \
+        --strip 1 -C /tmp/bashio \
+    \
+    && mv /tmp/bashio/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
+    && rm -f -r \
+        /tmp/* 
 
 ADD https://github.com/librespot-org/librespot-java/releases/download/v${LIBRESPOT_VERSION}/librespot-api-${LIBRESPOT_VERSION}.jar /opt/librespot-java.jar
+
+#FROM alpine:3.18
+FROM ghcr.io/linuxserver/baseimage-alpine:3.18 AS sps
+
+#RUN apk add  -U --update --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing shairport-sync 
+
+RUN apk -U add \
+        #alsa-lib-dev \
+        autoconf \
+        automake \
+        avahi-dev \
+        build-base \
+        #dbus \
+        ffmpeg-dev \
+        git \
+        libconfig-dev \
+        libgcrypt-dev \
+        libplist-dev \
+        libressl-dev \
+        libsndfile-dev \
+        libsodium-dev \
+        libtool \
+     #   mosquitto-dev \
+        popt-dev \
+        pulseaudio-dev \
+        soxr-dev \
+        xxd
+
+RUN cd /root \
+ && git clone https://github.com/mikebrady/shairport-sync.git \
+ && cd shairport-sync \
+ && autoreconf -i -f \
+ && ./configure \
+		    --prefix=/usr \
+		    --sysconfdir=/etc \
+        --with-pipe \
+        --with-pa \
+        --with-avahi \
+        --with-ssl=openssl \
+        --with-soxr \
+        --with-metadata \
+        #--with-mqtt-client \
+        --with-convolution \
+       #  --with-apple-alac \
+ && make \
+ && make install \
+ && cd / \
+ && apk --purge del \
+        git \
+        build-base \
+        autoconf \
+        automake \
+        libtool \
+        alsa-lib-dev \
+        libdaemon-dev \
+        popt-dev \
+        libressl-dev \
+        soxr-dev \
+        avahi-dev \
+        libconfig-dev \
+ && apk add \
+       # dbus \
+        #alsa-lib \
+        #alsa-plugins-pulse \
+        #libdaemon \
+        popt \
+        libressl \
+        soxr \
+        #avahi \
+        libconfig \
+        #mosquitto \
+ && rm -rf \
+        /etc/ssl \
+        /var/cache/apk/* \
+        /lib/apk/db/* \
+        /root/shairport-sync        
+
+COPY --from=owntone / /
 COPY root/ /
+
+
+#FROM ghcr.io/hassio-addons/base:14.2.0
+
+#RUN apk -U add \
+#        alsa-lib 
+
+#COPY --from=sps / /   
+#COPY / /     
+
+# ports and volumes
+EXPOSE 5000
+
+LABEL \
+  io.hass.arch="armhf|aarch64|i386|amd64" \
+    io.hass.name="Shairport Sync_owntone" \
+    io.hass.description="Shairport Sync owntone for Hass.io" \
+    io.hass.type="addon" \
+    io.hass.version="3.1" \
+    maintainer="Maido Käära <m@maido.io>"

--- a/owntone/Dockerfile
+++ b/owntone/Dockerfile
@@ -1,7 +1,4 @@
-
-
 FROM ghcr.io/linuxserver/daapd:28.8-ls122 AS owntone
-
 
 # renovate: datasource=github-releases depName=librespot-org/librespot-java
 ENV LIBRESPOT_VERSION=1.6.3
@@ -23,100 +20,12 @@ RUN echo "**** install java and remove librespot ****" && \
     && mv /tmp/bashio/lib /usr/lib/bashio \
     && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
     && rm -f -r \
-        /tmp/* 
+        /tmp/*  \
+    && apk add  -U --update --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing shairport-sync 
 
-ADD https://github.com/librespot-org/librespot-java/releases/download/v${LIBRESPOT_VERSION}/librespot-api-${LIBRESPOT_VERSION}.jar /opt/librespot-java.jar
+ADD https://github.com/librespot-org/librespot-java/releases/download/v${LIBRESPOT_VERSION}/librespot-api-${LIBRESPOT_VERSION}.jar /opt/librespot-java.jar 
 
-#FROM alpine:3.18
-FROM ghcr.io/linuxserver/baseimage-alpine:3.18 AS sps
-
-#RUN apk add  -U --update --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing shairport-sync 
-
-RUN apk -U add \
-        #alsa-lib-dev \
-        autoconf \
-        automake \
-        avahi-dev \
-        build-base \
-        #dbus \
-        ffmpeg-dev \
-        git \
-        libconfig-dev \
-        libgcrypt-dev \
-        libplist-dev \
-        libressl-dev \
-        libsndfile-dev \
-        libsodium-dev \
-        libtool \
-     #   mosquitto-dev \
-        popt-dev \
-        pulseaudio-dev \
-        soxr-dev \
-        xxd
-
-RUN cd /root \
- && git clone https://github.com/mikebrady/shairport-sync.git \
- && cd shairport-sync \
- && autoreconf -i -f \
- && ./configure \
-		    --prefix=/usr \
-		    --sysconfdir=/etc \
-        --with-pipe \
-        --with-pa \
-        --with-avahi \
-        --with-ssl=openssl \
-        --with-soxr \
-        --with-metadata \
-        #--with-mqtt-client \
-        --with-convolution \
-       #  --with-apple-alac \
- && make \
- && make install \
- && cd / \
- && apk --purge del \
-        git \
-        build-base \
-        autoconf \
-        automake \
-        libtool \
-        alsa-lib-dev \
-        libdaemon-dev \
-        popt-dev \
-        libressl-dev \
-        soxr-dev \
-        avahi-dev \
-        libconfig-dev \
- && apk add \
-       # dbus \
-        #alsa-lib \
-        #alsa-plugins-pulse \
-        #libdaemon \
-        popt \
-        libressl \
-        soxr \
-        #avahi \
-        libconfig \
-        #mosquitto \
- && rm -rf \
-        /etc/ssl \
-        /var/cache/apk/* \
-        /lib/apk/db/* \
-        /root/shairport-sync        
-
-COPY --from=owntone / /
 COPY root/ /
-
-
-#FROM ghcr.io/hassio-addons/base:14.2.0
-
-#RUN apk -U add \
-#        alsa-lib 
-
-#COPY --from=sps / /   
-#COPY / /     
-
-# ports and volumes
-EXPOSE 5000
 
 LABEL \
   io.hass.arch="armhf|aarch64|i386|amd64" \

--- a/owntone/README.md
+++ b/owntone/README.md
@@ -6,9 +6,16 @@ This is the offical Docker image of the Home Assistant add-on [HomePod Connect](
 
 This repository contains a customized version of [linuxserver/daapd](https://github.com/linuxserver/docker-daapd). In this image librespot is replaced by [librespot-java](https://github.com/librespot-org/librespot-java) and openjdk11-jre is installed. Also a custom [OwnTone](https://github.com/owntone/owntone-server) and [librespot-java](https://github.com/librespot-org/librespot-java) configuration is provided.
 
+In addition, [Shairport Sync](https://github.com/mikebrady/shairport-sync)
+is installed and can be optionally enabled on the configuration page to provide either or both these Airplay instances:
+
+1. An Airplay instance that will pipe audio and metadata to Owntone for whole house audio from any source that can play to an Airplay 1 device. This Airplay instance is hidden from OwnTone so it does not pipe back to OwnTone.
+
+2. An Airplay instance that will play to the audio device of the Home Assistant host.
+
 The changes can be viewed inside the `Dockerfile`. 
 
-This image is built automatically when a new linuxserver/daapd version is released.
+This image is built automatically when a new linuxserver/daapd or Shairport Sync version is released.
 
 ## Usage
 
@@ -34,5 +41,11 @@ All configuration files are stored inside the docker image in `/config/owntone`.
 
 - [`librespot-java.toml`](https://github.com/AlexanderBabel/owntone/blob/main/root/defaults/librespot-java.toml) - Configuration for [librespot-java](https://github.com/librespot-org/librespot-java)
 - [`owntone.conf`](https://github.com/AlexanderBabel/owntone/blob/main/root/defaults/owntone.conf) - Configuration for [OwnTone](https://github.com/owntone/owntone-server)
+- [`shairport-sync-pipe.conf`](https://github.com/AlexanderBabel/owntone/blob/main/root/defaults/shairport-sync-pipe.conf) - Configuration for [Shairport Sync](https://github.com/mikebrady/shairport-sync)
+- [`shairport-sync-audio.conf`](https://github.com/AlexanderBabel/owntone/blob/main/root/defaults/shairport-sync-audio.conf) - Configuration for [Shairport Sync](https://github.com/mikebrady/shairport-sync)
 
-Both files are adjusted to work out of the box as a Spotify Connect speaker. The content of these files can be found in this repository.
+All files are adjusted to work out of the box as a Spotify Connect speaker. The content of these files can be found in this repository.
+
+The configuration page allows you to enable/disable the Airplay instances, name them them, change the tcp/udp port if needed, and choose from two logging levels.
+
+Also on the configuration page, the [librespot-java](https://github.com/librespot-org/librespot-java) cache can be enabled/disabled and the Home Assistant audio device can be chosen.

--- a/owntone/root/etc/s6-overlay/s6-rc.d/init-daapd-config/run
+++ b/owntone/root/etc/s6-overlay/s6-rc.d/init-daapd-config/run
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/usr/bin/with-contenv bashio
 # shellcheck shell=bash
 
 # make our folders
@@ -53,8 +53,32 @@ if [[ ! -f /config/owntone/librespot-java.toml ]]; then
     cp /defaults/librespot-java.toml /config/owntone/librespot-java.toml
 fi
 
+# Set cache true or false
+if $(bashio::config 'librespot_java_cache'); then
+    sed -i '/\[cache\]/,/^\tenabled = .*$/ s/^\tenabled = .*$/\tenabled = true/' /config/owntone/librespot-java.toml
+else
+    sed -i '/\[cache\]/,/^\tenabled = .*$/ s/^\tenabled = .*$/\tenabled = false/' /config/owntone/librespot-java.toml
+fi
+
 # permissions
 lsiown -R abc:abc \
     /app \
     /config/owntone \
     /daapd-pidfolder
+
+# Set cache true or false
+if $(bashio::config 'airplay_pipe'); then
+    LINE='airplay "'$(bashio::config 'airplay_pipe_name')'" { exclude = true } # Exclude airplay_pipe device from owntone device list'
+    FILE='/config/owntone/owntone.conf'
+    sed -i '/{ exclude = true } # Exclude airplay_pipe device from owntone device list/d' $FILE
+    grep -qF -- "$LINE" "$FILE" || echo "$LINE" >> "$FILE"    
+fi
+
+# configure defaults copy of conf
+#if [[ ! -e "/defaults/shairport-sync.conf" ]]; then
+ #   cp /etc/shairport-sync.conf.sample /defaults/shairport-sync.conf
+#sed -i \
+#    -e   's_//\tname = "/tmp/shairport-sync-audio"; // this is the default_//\tname = "/music/librespot-java"; // this is the default _g'  \
+#	-e   's#//\tpipe_name = "/tmp/shairport-sync-metadata";#//\tpipe_name = "/music/librespot-java.metadata";#g' \
+#     /defaults/shairport-sync.conf
+#fi     

--- a/owntone/root/etc/services.d/shairport-sync-audio/run
+++ b/owntone/root/etc/services.d/shairport-sync-audio/run
@@ -1,0 +1,38 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Community Hass.io Add-ons: Shairport Sync
+# Starts the Shairport Sync service
+# ==============================================================================
+# shellcheck disable=SC1091
+
+if $(bashio::config 'airplay_audio'); then
+
+#sleep 5
+# Wait for Avahi to become available
+s6-svwait -u -t 5000 /var/run/service/svc-avahi
+
+# Wait at least 5 seconds before starting
+# Avahi might need some time.
+#sleep 4
+
+declare airplay_audio_name
+
+if bashio::config.has_value 'airplay_audio_name'; then
+    airplay_audio_name=$(bashio::config 'airplay_audio_name')
+else
+    airplay_audio_name=$(bashio::info.hostname)
+fi
+
+#exec /usr/bin/shairport-sync -v -p 5001 -a haoppa -o pa 
+
+	exec /usr/bin/shairport-sync \
+    -$(bashio::config 'shairport_sync_log_level') \
+    -p $(bashio::config 'airplay_audio_port') \
+    -a "$airplay_audio_name"  \
+    -o pa  \
+    -c /config/owntone/shairport-sync.conf \
+    --displayConfig 
+fi
+
+    #-c /config/owntone/shairport-sync.conf --displayConfig \
+    #--metadata-enable 

--- a/owntone/root/etc/services.d/shairport-sync-pipe/run
+++ b/owntone/root/etc/services.d/shairport-sync-pipe/run
@@ -1,0 +1,42 @@
+#!/usr/bin/with-contenv bashio
+# ==============================================================================
+# Community Hass.io Add-ons: Shairport Sync
+# Starts the Shairport Sync service
+# ==============================================================================
+# shellcheck disable=SC1091
+
+if $(bashio::config 'airplay_pipe'); then
+
+#sleep 5
+# Wait for Avahi to become available
+s6-svwait -u -t 5000 /var/run/service/svc-avahi
+
+# Wait at least 5 seconds before starting
+# Avahi might need some time.
+#sleep 4
+
+declare airplay_pipe_name
+
+if bashio::config.has_value 'airplay_pipe_name'; then
+    airplay_pipe_name=$(bashio::config 'airplay_pipe_name')
+else
+    airplay_pipe_name=$(bashio::info.hostname)
+fi
+
+#exec /usr/bin/shairport-sync -v -p 5003 -a haopipe -o pipe /music/librespot-java 
+
+	exec /usr/bin/shairport-sync \
+    -$(bashio::config 'shairport_sync_log_level') \
+    -p $(bashio::config 'airplay_pipe_port') \
+    -a "$airplay_pipe_name"  \
+    -o pipe /music/librespot-java \
+	-B "/usr/bin/curl -X POST http://localhost:24879/player/pause" \
+    -c /config/owntone/shairport-sync-pipe.conf \
+    --displayConfig 
+
+fi
+
+
+#	-meta-dir = /music/librespot-java.metadata \
+    #-c /config/owntone/shairport-sync.conf --displayConfig \
+    #--metadata-enable 

--- a/owntone/root/etc/services.d/versions-V/run
+++ b/owntone/root/etc/services.d/versions-V/run
@@ -1,0 +1,11 @@
+#!/usr/bin/with-contenv bash
+# ==============================================================================
+# Community Hass.io Add-ons: Shairport Sync
+# Starts the Shairport Sync service
+# ==============================================================================
+# shellcheck disable=SC1091
+
+/usr/sbin/owntone -v > /config/owntone/versions.txt
+/usr/bin/shairport-sync -V >> /config/owntone/versions.txt
+avahi-daemon -V >> /config/owntone/versions.txt
+#ls -R / > /config/owntone/versions.txt


### PR DESCRIPTION
I have been using this setup in Debian for while using librespot java and Owntone with two shairport-sync instances. One instance is an Airplay 1 receiver that pipes audio and metadata to owntone so that any device that can play to Airplay 1 can play to owntone multi-room audio. The second is an Airplay 1 receiver that plays to the Home Assistant pulse-audio device so that should there be an audio device on the Home Assistant server in can play synchronized with the rest of the multi-room receivers from owntone.

I have been putting this setup through the paces for a while and it works flawlessly.  I tied to make it as easy to understand and implement users with a configuration page updates to the readme.  I do hope you will consider this functionality for HomePod Connect as it will make it the best,most flexible and easiest to maintain all in one multiroom audio system around.

I am new to github pull requests so I hope you will be patient with me.

Thanks,
ivolt1